### PR TITLE
Measurements auth

### DIFF
--- a/app/src/main/java/com/expidev/gcmapp/Constants.java
+++ b/app/src/main/java/com/expidev/gcmapp/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
     public static final String EXTRA_TRAINING_IDS = "training_ids";
 
     /* result codes */
-    public static final int BLOCKED_MINISTRY = 0;
+    public static final int BLOCKED_MINISTRY = 1;
 
     /* request codes */
     public static final int REQUEST_EXIT = 1;

--- a/app/src/main/java/com/expidev/gcmapp/Constants.java
+++ b/app/src/main/java/com/expidev/gcmapp/Constants.java
@@ -21,4 +21,10 @@ public class Constants {
     public static final String EXTRA_CHURCH_IDS = "church_ids";
     public static final String EXTRA_MINISTRY_ID = "ministry_id";
     public static final String EXTRA_TRAINING_IDS = "training_ids";
+
+    /* result codes */
+    public static final int BLOCKED_MINISTRY = 0;
+
+    /* request codes */
+    public static final int REQUEST_EXIT = 1;
 }

--- a/app/src/main/java/com/expidev/gcmapp/MainActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MainActivity.java
@@ -406,7 +406,7 @@ public class MainActivity extends ActionBarActivity
 
     public void goToMeasurements(MenuItem menuItem)
     {
-        if(mAssignment != null && mAssignment.getRole() == Assignment.Role.BLOCKED)
+        if(mAssignment != null && mAssignment.isBlocked())
         {
             AlertDialog alertDialog = new AlertDialog.Builder(this)
                 .setTitle(getString(R.string.title_dialog_blocked))

--- a/app/src/main/java/com/expidev/gcmapp/MainActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MainActivity.java
@@ -397,8 +397,8 @@ public class MainActivity extends ActionBarActivity
         if(mAssignment != null && mAssignment.getRole() == Assignment.Role.BLOCKED)
         {
             AlertDialog alertDialog = new AlertDialog.Builder(this)
-                .setTitle("Blocked")
-                .setMessage("You are not allowed to view measurements for this ministry")
+                .setTitle(getString(R.string.title_dialog_blocked))
+                .setMessage(getString(R.string.disallowed_measurements))
                 .setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener()
                 {
                     public void onClick(DialogInterface dialog, int which)

--- a/app/src/main/java/com/expidev/gcmapp/MainActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MainActivity.java
@@ -394,7 +394,26 @@ public class MainActivity extends ActionBarActivity
 
     public void goToMeasurements(MenuItem menuItem)
     {
-        startActivity(new Intent(getApplicationContext(), MeasurementsActivity.class));
+        if(mAssignment != null && mAssignment.getRole() == Assignment.Role.BLOCKED)
+        {
+            AlertDialog alertDialog = new AlertDialog.Builder(this)
+                .setTitle("Blocked")
+                .setMessage("You are not allowed to view measurements for this ministry")
+                .setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener()
+                {
+                    public void onClick(DialogInterface dialog, int which)
+                    {
+                        dialog.dismiss();
+                    }
+                })
+                .create();
+
+            alertDialog.show();
+        }
+        else
+        {
+            startActivity(new Intent(getApplicationContext(), MeasurementsActivity.class));
+        }
     }
 
     public void reset(MenuItem menuItem)

--- a/app/src/main/java/com/expidev/gcmapp/MainActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MainActivity.java
@@ -162,8 +162,12 @@ public class MainActivity extends ActionBarActivity
             MinistriesService.syncAssignments(this, theKey.getGuid());
 
             if (mAssignment != null) {
-                MeasurementsService
-                        .syncMeasurements(this, mAssignment.getMinistryId(), mAssignment.getMcc().toString(), null);
+                MeasurementsService.syncMeasurements(
+                    this,
+                    mAssignment.getMinistryId(),
+                    mAssignment.getMcc().toString(),
+                    null,
+                    mAssignment.getRole());
             }
         }
     }
@@ -193,8 +197,12 @@ public class MainActivity extends ActionBarActivity
                 MinistriesService.syncAssignments(this, theKey.getGuid(), true);
                 if (mAssignment != null) {
                     MinistriesService.syncChurches(this, mAssignment.getMinistryId());
-                    MeasurementsService
-                            .syncMeasurements(this, mAssignment.getMinistryId(), mAssignment.getMcc().toString(), null);
+                    MeasurementsService.syncMeasurements(
+                        this,
+                        mAssignment.getMinistryId(),
+                        mAssignment.getMcc().toString(),
+                        null,
+                        mAssignment.getRole());
                 }
 
                 return true;
@@ -243,8 +251,12 @@ public class MainActivity extends ActionBarActivity
         if (mAssignment != null) {
             MinistriesService.syncChurches(this, mAssignment.getMinistryId());
             TrainingService.downloadTraining(this, mAssignment.getMinistryId(), mAssignment.getMcc());
-            MeasurementsService
-                    .syncMeasurements(this, mAssignment.getMinistryId(), mAssignment.getMcc().toString(), null);
+            MeasurementsService.syncMeasurements(
+                this,
+                mAssignment.getMinistryId(),
+                mAssignment.getMcc().toString(),
+                null,
+                mAssignment.getRole());
         }
 
         // restart Loaders based off the current ministry

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -420,8 +420,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
         for(BreakdownData localDataSource : localBreakdown)
         {
-            //TODO: Should we skip 0 value rows?
-            if("total".equals(localDataSource.getSource())) // || localDataSource.getSource() == 0)
+            if("total".equals(localDataSource.getSource()))
             {
                 continue;
             }

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -441,7 +441,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
             dataSection.addView(localDataInputSection);
         }
-        else // Member
+        else if(isMember())
         {
             LinearLayout localDataInputSection = createRow(
                 "Local",
@@ -455,14 +455,17 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
         dataSection.addView(teamMembersSectionTitle);
 
-        EditText personalNumber = createInputView(
-            measurementDetails.getSelfBreakdown().get(0).getAmount(),
-            PERSONAL_MEASUREMENTS_TAG);
-        LinearLayout personalDataInputSection = createRow(createNameView("You"), personalNumber);
+        if(!isInheritedLeader())
+        {
+            EditText personalNumber = createInputView(
+                measurementDetails.getSelfBreakdown().get(0).getAmount(),
+                PERSONAL_MEASUREMENTS_TAG);
+            LinearLayout personalDataInputSection = createRow(createNameView("You"), personalNumber);
 
-        dataSection.addView(personalDataInputSection);
+            dataSection.addView(personalDataInputSection);
+        }
 
-        if(isLeader())
+        if(isLeader() || isInheritedLeader())
         {
             addTeamMemberSection(dataSection, measurementDetails);
             addSubMinistriesSection(dataSection, measurementDetails);
@@ -472,9 +475,17 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
     private boolean isLeader()
     {
-        return currentAssignment != null &&
-            (currentAssignment.getRole() == Assignment.Role.LEADER ||
-                currentAssignment.getRole() == Assignment.Role.INHERITED_LEADER);
+        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.LEADER;
+    }
+
+    private boolean isInheritedLeader()
+    {
+        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.INHERITED_LEADER;
+    }
+
+    private boolean isMember()
+    {
+        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.MEMBER;
     }
 
     private void addTeamMemberSection(LinearLayout dataSection, MeasurementDetails measurementDetails)

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -431,7 +431,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
             dataSection.addView(new HorizontalLineView(this));
         }
 
-        if(isLeader())
+        if(isLeader() || isInheritedLeader())
         {
             EditText localNumber = createInputView(
                 measurementDetails.getTotalLocalBreakdown().getAmount(),

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -473,6 +473,11 @@ public class MeasurementDetailsActivity extends ActionBarActivity
         {
             addTeamMemberSection(dataSection, measurementDetails);
         }
+        else if(isMember())
+        {
+            // Members can view the total team member amount
+            addTeamMemberTotalSection(dataSection, measurementDetails);
+        }
 
         // Everyone except self-assigned (and blocked, who can't get to this page) can see sub-ministry details
         if(!isSelfAssigned())
@@ -521,6 +526,20 @@ public class MeasurementDetailsActivity extends ActionBarActivity
             LinearLayout row = createRow(name, teamMemberDetails.getTotal());
             dataSection.addView(row);
         }
+    }
+
+    private void addTeamMemberTotalSection(LinearLayout dataSection, MeasurementDetails measurementDetails)
+    {
+        int total = 0;
+        List<TeamMemberDetails> teamMemberDetailsList = measurementDetails.getTeamMemberDetails();
+
+        for(TeamMemberDetails teamMemberDetails : teamMemberDetailsList)
+        {
+            total += teamMemberDetails.getTotal();
+        }
+
+        LinearLayout row = createRow("Others:", total);
+        dataSection.addView(row);
     }
 
     private void addSubMinistriesSection(LinearLayout dataSection, MeasurementDetails measurementDetails)

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -472,6 +472,11 @@ public class MeasurementDetailsActivity extends ActionBarActivity
         if(isLeader() || isInheritedLeader())
         {
             addTeamMemberSection(dataSection, measurementDetails);
+
+            HorizontalLineView horizontalLine = new HorizontalLineView(this);
+            dataSection.addView(horizontalLine);
+
+            addTeamMemberTotalSection(dataSection, measurementDetails);
         }
         else if(isMember())
         {
@@ -538,7 +543,9 @@ public class MeasurementDetailsActivity extends ActionBarActivity
             total += teamMemberDetails.getTotal();
         }
 
-        LinearLayout row = createRow("Others:", total);
+        total += measurementDetails.getSelfBreakdown().get(0).getAmount();
+
+        LinearLayout row = createRow("TOTAL", total);
         dataSection.addView(row);
     }
 

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -468,10 +468,21 @@ public class MeasurementDetailsActivity extends ActionBarActivity
             dataSection.addView(personalDataInputSection);
         }
 
+        // Only leaders and inherited leaders can see team member details
         if(isLeader() || isInheritedLeader())
         {
             addTeamMemberSection(dataSection, measurementDetails);
+        }
+
+        // Everyone except self-assigned (and blocked, who can't get to this page) can see sub-ministry details
+        if(!isSelfAssigned())
+        {
             addSubMinistriesSection(dataSection, measurementDetails);
+        }
+
+        // Only leaders and inherited leaders can see self-assigned details
+        if(isLeader() || isInheritedLeader())
+        {
             addSelfAssignedSection(dataSection, measurementDetails);
         }
     }
@@ -489,6 +500,11 @@ public class MeasurementDetailsActivity extends ActionBarActivity
     private boolean isMember()
     {
         return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.MEMBER;
+    }
+
+    private boolean isSelfAssigned()
+    {
+        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.SELF_ASSIGNED;
     }
 
     private void addTeamMemberSection(LinearLayout dataSection, MeasurementDetails measurementDetails)

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -416,32 +416,35 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
         dataSection.addView(totalNumberTitle);
 
-        List<BreakdownData> localBreakdown = measurementDetails.getLocalBreakdown();
-
-        for(BreakdownData localDataSource : localBreakdown)
-        {
-            if("total".equals(localDataSource.getSource()))
-            {
-                continue;
-            }
-
-            LinearLayout row = createRow(localDataSource.getSource(), localDataSource.getAmount());
-            dataSection.addView(row);
-
-            dataSection.addView(new HorizontalLineView(this));
-        }
-
+        // Only leaders and inherited leaders can see the local breakdown
         if(isLeader() || isInheritedLeader())
         {
-            EditText localNumber = createInputView(
-                measurementDetails.getTotalLocalBreakdown().getAmount(),
-                LOCAL_MEASUREMENTS_TAG);
-            LinearLayout localDataInputSection = createRow(createNameView("Local"), localNumber);
+            List<BreakdownData> localBreakdown = measurementDetails.getLocalBreakdown();
 
-            dataSection.addView(localDataInputSection);
+            for(BreakdownData localDataSource : localBreakdown)
+            {
+                if("total".equals(localDataSource.getSource()))
+                {
+                    continue;
+                }
+
+                LinearLayout row = createRow(localDataSource.getSource(), localDataSource.getAmount());
+                dataSection.addView(row);
+
+                dataSection.addView(new HorizontalLineView(this));
+
+                // Only leaders and inherited leaders can edit local values
+                EditText localNumber = createInputView(
+                    measurementDetails.getTotalLocalBreakdown().getAmount(),
+                    LOCAL_MEASUREMENTS_TAG);
+                LinearLayout localDataInputSection = createRow(createNameView("Local"), localNumber);
+
+                dataSection.addView(localDataInputSection);
+            }
         }
         else if(isMember())
         {
+            // Members can see the local total, but not edit it
             LinearLayout localDataInputSection = createRow(
                 "Local",
                 measurementDetails.getTotalLocalBreakdown().getAmount()
@@ -454,6 +457,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
         dataSection.addView(teamMembersSectionTitle);
 
+        // Inherited leaders do not have personal measurements
         if(!isInheritedLeader())
         {
             EditText personalNumber = createInputView(

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -437,15 +437,15 @@ public class MeasurementDetailsActivity extends ActionBarActivity
                 dataSection.addView(row);
 
                 dataSection.addView(new HorizontalLineView(this));
-
-                // Only leaders and inherited leaders can edit local values
-                EditText localNumber = createInputView(
-                    measurementDetails.getTotalLocalBreakdown().getAmount(),
-                    LOCAL_MEASUREMENTS_TAG);
-                LinearLayout localDataInputSection = createRow(createNameView("Local"), localNumber);
-
-                dataSection.addView(localDataInputSection);
             }
+
+            // Only leaders and inherited leaders can edit local values
+            EditText localNumber = createInputView(
+                measurementDetails.getTotalLocalBreakdown().getAmount(),
+                LOCAL_MEASUREMENTS_TAG);
+            LinearLayout localDataInputSection = createRow(createNameView("Local"), localNumber);
+
+            dataSection.addView(localDataInputSection);
         }
         else if(currentAssignment.isMember())
         {

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -749,7 +749,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
             currentAssignment = assignment;
             Log.i(TAG, "Current assignment loaded");
 
-            if(currentAssignment.getRole() == Assignment.Role.BLOCKED)
+            if(currentAssignment.isBlocked())
             {
                 AlertDialog alertDialog = new AlertDialog.Builder(this)
                     .setTitle(getString(R.string.title_dialog_blocked))

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -1,5 +1,7 @@
 package com.expidev.gcmapp;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.AsyncTask;
@@ -705,6 +707,25 @@ public class MeasurementDetailsActivity extends ActionBarActivity
         {
             currentAssignment = assignment;
             Log.i(TAG, "Current assignment loaded");
+
+            if(currentAssignment.getRole() == Assignment.Role.BLOCKED)
+            {
+                AlertDialog alertDialog = new AlertDialog.Builder(this)
+                    .setTitle(getString(R.string.title_dialog_blocked))
+                    .setMessage(getString(R.string.disallowed_measurements))
+                    .setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener()
+                    {
+                        public void onClick(DialogInterface dialog, int which)
+                        {
+                            dialog.dismiss();
+                            setResult(Constants.BLOCKED_MINISTRY);
+                            finish();
+                        }
+                    })
+                    .create();
+
+                alertDialog.show();
+            }
         }
     }
 

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementDetailsActivity.java
@@ -408,6 +408,11 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
     private void initializeDataSection(MeasurementDetails measurementDetails)
     {
+        if(currentAssignment == null)
+        {
+            return;
+        }
+
         TextHeaderView totalNumberTitle = new TextHeaderView(this);
         totalNumberTitle.setText(ministryName);
 
@@ -417,7 +422,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
         dataSection.addView(totalNumberTitle);
 
         // Only leaders and inherited leaders can see the local breakdown
-        if(isLeader() || isInheritedLeader())
+        if(currentAssignment.isLeadership())
         {
             List<BreakdownData> localBreakdown = measurementDetails.getLocalBreakdown();
 
@@ -442,7 +447,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
                 dataSection.addView(localDataInputSection);
             }
         }
-        else if(isMember())
+        else if(currentAssignment.isMember())
         {
             // Members can see the local total, but not edit it
             LinearLayout localDataInputSection = createRow(
@@ -458,7 +463,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
         dataSection.addView(teamMembersSectionTitle);
 
         // Inherited leaders do not have personal measurements
-        if(!isInheritedLeader())
+        if(!currentAssignment.isInheritedLeader())
         {
             EditText personalNumber = createInputView(
                 measurementDetails.getSelfBreakdown().get(0).getAmount(),
@@ -469,7 +474,7 @@ public class MeasurementDetailsActivity extends ActionBarActivity
         }
 
         // Only leaders and inherited leaders can see team member details
-        if(isLeader() || isInheritedLeader())
+        if(currentAssignment.isLeadership())
         {
             addTeamMemberSection(dataSection, measurementDetails);
 
@@ -478,43 +483,23 @@ public class MeasurementDetailsActivity extends ActionBarActivity
 
             addTeamMemberTotalSection(dataSection, measurementDetails);
         }
-        else if(isMember())
+        else if(currentAssignment.isMember())
         {
             // Members can view the total team member amount
             addTeamMemberTotalSection(dataSection, measurementDetails);
         }
 
         // Everyone except self-assigned (and blocked, who can't get to this page) can see sub-ministry details
-        if(!isSelfAssigned())
+        if(!currentAssignment.isSelfAssigned())
         {
             addSubMinistriesSection(dataSection, measurementDetails);
         }
 
         // Only leaders and inherited leaders can see self-assigned details
-        if(isLeader() || isInheritedLeader())
+        if(currentAssignment.isLeadership())
         {
             addSelfAssignedSection(dataSection, measurementDetails);
         }
-    }
-
-    private boolean isLeader()
-    {
-        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.LEADER;
-    }
-
-    private boolean isInheritedLeader()
-    {
-        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.INHERITED_LEADER;
-    }
-
-    private boolean isMember()
-    {
-        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.MEMBER;
-    }
-
-    private boolean isSelfAssigned()
-    {
-        return currentAssignment != null && currentAssignment.getRole() == Assignment.Role.SELF_ASSIGNED;
     }
 
     private void addTeamMemberSection(LinearLayout dataSection, MeasurementDetails measurementDetails)

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
@@ -93,6 +93,18 @@ public class MeasurementsActivity extends ActionBarActivity
         startLoaders();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        if(requestCode == Constants.REQUEST_EXIT)
+        {
+            if(resultCode == Constants.BLOCKED_MINISTRY)
+            {
+                finish();
+            }
+        }
+    }
+
     private void startLoaders()
     {
         final LoaderManager manager = this.getSupportLoaderManager();
@@ -336,7 +348,7 @@ public class MeasurementsActivity extends ActionBarActivity
             goToMeasurementDetails.putExtra(Constants.ARG_PERIOD, currentPeriod);
         }
 
-        startActivity(goToMeasurementDetails);
+        startActivityForResult(goToMeasurementDetails, Constants.REQUEST_EXIT);
     }
 
     public void goToPreviousPeriod(View view)
@@ -411,8 +423,8 @@ public class MeasurementsActivity extends ActionBarActivity
         if(mAssignment != null && mAssignment.getRole() == Assignment.Role.BLOCKED)
         {
             AlertDialog alertDialog = new AlertDialog.Builder(this)
-                .setTitle("Blocked")
-                .setMessage("You are not allowed to view measurements for this ministry")
+                .setTitle(getString(R.string.title_dialog_blocked))
+                .setMessage(getString(R.string.disallowed_measurements))
                 .setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener()
                 {
                     public void onClick(DialogInterface dialog, int which)
@@ -425,7 +437,7 @@ public class MeasurementsActivity extends ActionBarActivity
 
             alertDialog.show();
         }
-        
+
         chosenMinistry = mAssignment != null ? mAssignment.getMinistry() : null;
 
         if (chosenMinistry != null) {

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
@@ -1,6 +1,8 @@
 package com.expidev.gcmapp;
 
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
@@ -405,6 +407,25 @@ public class MeasurementsActivity extends ActionBarActivity
 
     void onLoadCurrentAssignment(@Nullable final Assignment assignment) {
         mAssignment = assignment;
+
+        if(mAssignment != null && mAssignment.getRole() == Assignment.Role.BLOCKED)
+        {
+            AlertDialog alertDialog = new AlertDialog.Builder(this)
+                .setTitle("Blocked")
+                .setMessage("You are not allowed to view measurements for this ministry")
+                .setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener()
+                {
+                    public void onClick(DialogInterface dialog, int which)
+                    {
+                        dialog.dismiss();
+                        finish();
+                    }
+                })
+                .create();
+
+            alertDialog.show();
+        }
+        
         chosenMinistry = mAssignment != null ? mAssignment.getMinistry() : null;
 
         if (chosenMinistry != null) {

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
@@ -421,7 +421,7 @@ public class MeasurementsActivity extends ActionBarActivity
     void onLoadCurrentAssignment(@Nullable final Assignment assignment) {
         mAssignment = assignment;
 
-        if(mAssignment != null && mAssignment.getRole() == Assignment.Role.BLOCKED)
+        if(mAssignment != null && mAssignment.isBlocked())
         {
             AlertDialog alertDialog = new AlertDialog.Builder(this)
                 .setTitle(getString(R.string.title_dialog_blocked))

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
@@ -287,7 +287,9 @@ public class MeasurementsActivity extends ActionBarActivity
             @Override
             public int compare(Measurement lhs, Measurement rhs)
             {
-                return Integer.compare(lhs.getSortOrder(), rhs.getSortOrder());
+                return lhs.getSortOrder() < rhs.getSortOrder()
+                    ? -1
+                    : (lhs.getSortOrder() == rhs.getSortOrder() ? 0 : 1);
             }
         };
     }

--- a/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
+++ b/app/src/main/java/com/expidev/gcmapp/MeasurementsActivity.java
@@ -39,6 +39,7 @@ import org.json.JSONArray;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;

--- a/app/src/main/java/com/expidev/gcmapp/model/Assignment.java
+++ b/app/src/main/java/com/expidev/gcmapp/model/Assignment.java
@@ -199,4 +199,29 @@ public class Assignment extends Base implements Cloneable, Serializable {
     {
         return "id: " + id;
     }
+
+    public boolean isLeader()
+    {
+        return getRole() == Assignment.Role.LEADER;
+    }
+
+    public boolean isInheritedLeader()
+    {
+        return getRole() == Assignment.Role.INHERITED_LEADER;
+    }
+
+    public boolean isLeadership()
+    {
+        return isLeader() || isInheritedLeader();
+    }
+
+    public boolean isMember()
+    {
+        return getRole() == Assignment.Role.MEMBER;
+    }
+
+    public boolean isSelfAssigned()
+    {
+        return getRole() == Assignment.Role.SELF_ASSIGNED;
+    }
 }

--- a/app/src/main/java/com/expidev/gcmapp/model/Assignment.java
+++ b/app/src/main/java/com/expidev/gcmapp/model/Assignment.java
@@ -202,12 +202,12 @@ public class Assignment extends Base implements Cloneable, Serializable {
 
     public boolean isLeader()
     {
-        return getRole() == Assignment.Role.LEADER;
+        return getRole() == Role.LEADER;
     }
 
     public boolean isInheritedLeader()
     {
-        return getRole() == Assignment.Role.INHERITED_LEADER;
+        return getRole() == Role.INHERITED_LEADER;
     }
 
     public boolean isLeadership()
@@ -217,11 +217,16 @@ public class Assignment extends Base implements Cloneable, Serializable {
 
     public boolean isMember()
     {
-        return getRole() == Assignment.Role.MEMBER;
+        return getRole() == Role.MEMBER;
     }
 
     public boolean isSelfAssigned()
     {
-        return getRole() == Assignment.Role.SELF_ASSIGNED;
+        return getRole() == Role.SELF_ASSIGNED;
+    }
+
+    public boolean isBlocked()
+    {
+        return getRole() == Role.BLOCKED;
     }
 }

--- a/app/src/main/java/com/expidev/gcmapp/service/MeasurementsService.java
+++ b/app/src/main/java/com/expidev/gcmapp/service/MeasurementsService.java
@@ -12,6 +12,7 @@ import com.expidev.gcmapp.Constants;
 import com.expidev.gcmapp.db.MeasurementDao;
 import com.expidev.gcmapp.http.GmaApiClient;
 import com.expidev.gcmapp.json.MeasurementsJsonParser;
+import com.expidev.gcmapp.model.Assignment;
 import com.expidev.gcmapp.model.measurement.Measurement;
 import com.expidev.gcmapp.model.measurement.MeasurementDetails;
 
@@ -24,6 +25,7 @@ import org.json.JSONObject;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -131,7 +133,8 @@ public class MeasurementsService extends ThreadedIntentService
         final Context context,
         String ministryId,
         String mcc,
-        String period)
+        String period,
+        Assignment.Role role)
     {
         Bundle extras = new Bundle(4);
 
@@ -139,6 +142,7 @@ public class MeasurementsService extends ThreadedIntentService
         extras.putString(Constants.ARG_MINISTRY_ID, ministryId);
         extras.putString(Constants.ARG_MCC, mcc);
         extras.putString(Constants.ARG_PERIOD, setPeriodToCurrentIfNecessary(period));
+        extras.putSerializable("role", role);
 
         context.startService(baseIntent(context, extras));
     }
@@ -264,6 +268,7 @@ public class MeasurementsService extends ThreadedIntentService
         String ministryId = intent.getStringExtra(Constants.ARG_MINISTRY_ID);
         String mcc = intent.getStringExtra(Constants.ARG_MCC);
         String period = intent.getStringExtra(Constants.ARG_PERIOD);
+        Assignment.Role role = (Assignment.Role) intent.getSerializableExtra("role");
 
         if(ministryId == null || mcc == null)
         {
@@ -299,27 +304,37 @@ public class MeasurementsService extends ThreadedIntentService
             updateMeasurements(measurements);
         }
 
-        List<MeasurementDetails> measurementDetailsList = new ArrayList<>();
+        final List<Assignment.Role> rolesWithDetailsPermissions = Arrays.asList(
+            Assignment.Role.LEADER,
+            Assignment.Role.INHERITED_LEADER,
+            Assignment.Role.MEMBER
+        );
 
-        // retrieve and save all measurement details for the measurements retrieved
-        for(Measurement measurement : measurements)
+        // Skip loading measurement details if it just returns a 401 anyway
+        if(rolesWithDetailsPermissions.contains(role))
         {
-            MeasurementDetails measurementDetails = retrieveDetailsForMeasurement(
-                measurement.getMeasurementId(),
-                measurement.getMinistryId(),
-                measurement.getMcc(),
-                measurement.getPeriod());
+            List<MeasurementDetails> measurementDetailsList = new ArrayList<>();
 
-            if(measurementDetails != null)
+            // retrieve and save all measurement details for the measurements retrieved
+            for(Measurement measurement : measurements)
             {
-                measurementDetailsList.add(measurementDetails);
-            }
-        }
+                MeasurementDetails measurementDetails = retrieveDetailsForMeasurement(
+                    measurement.getMeasurementId(),
+                    measurement.getMinistryId(),
+                    measurement.getMcc(),
+                    measurement.getPeriod());
 
-        if(!measurementDetailsList.isEmpty())
-        {
-            Log.d(TAG, "Updating measurement details...");
-            updateMeasurementDetails(measurementDetailsList);
+                if(measurementDetails != null)
+                {
+                    measurementDetailsList.add(measurementDetails);
+                }
+            }
+
+            if(!measurementDetailsList.isEmpty())
+            {
+                Log.d(TAG, "Updating measurement details...");
+                updateMeasurementDetails(measurementDetailsList);
+            }
         }
     }
 

--- a/app/src/main/java/com/expidev/gcmapp/service/MeasurementsService.java
+++ b/app/src/main/java/com/expidev/gcmapp/service/MeasurementsService.java
@@ -289,6 +289,11 @@ public class MeasurementsService extends ThreadedIntentService
             measurements.addAll(previousPeriodMeasurements);
         }
 
+        if(measurements == null)
+        {
+            return;
+        }
+
         if(!measurements.isEmpty())
         {
             updateMeasurements(measurements);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="title_activity_measurements">Measurements</string>
     <string name="title_activity_measurement_details">Measurement Details</string>
     <string name="title_activity_settings">Settings</string>
+    <string name="title_dialog_blocked">Blocked</string>
 
     <!-- Menu items -->
     <string name="menu_refresh">Refresh</string>
@@ -46,6 +47,7 @@
     <!-- Messages -->
     <string name="no_internet">No network connection detected</string>
     <string name="logout_message">Are you sure you want to logout?</string>
+    <string name="disallowed_measurements">You are not allowed to view measurements for this ministry</string>
 
     <!-- Map Settings -->
     <string name="map_settings">Map Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,9 +2,9 @@
 <resources>
 
     <!-- Titles -->
-    <string name="app_name">GCM App</string>
-    <string name="title_activity_main">GCM App</string>
-    <string name="title_activity_join_ministry">GCM App</string>
+    <string name="app_name">GMA App</string>
+    <string name="title_activity_main">GMA App</string>
+    <string name="title_activity_join_ministry">Join Ministry</string>
     <string name="title_activity_map_settings">MapSettings</string>
     <string name="title_activity_measurements">Measurements</string>
     <string name="title_activity_measurement_details">Measurement Details</string>
@@ -16,7 +16,7 @@
 
     <!-- Main Activity -->
     <string name="logout">Logout</string>
-    <string name="hello_world">Welcome to the GCM App!</string>
+    <string name="hello_world">Welcome to the GMA App!</string>
     <string name="action_settings">Settings</string>
     <string name="reset">Reset</string>
     <string name="action_join_new_ministry">Join new ministry</string>


### PR DESCRIPTION
Handles authorization for measurements and measurement details
Does not handle self-assigned measurements (They do not have access to download measurement details, so that page does not come up for them. Need to allow them to edit the numbers on MeasurementsActivity and make sure those point to the correct fields in the database/model).