### PR TITLE
load stetho for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,8 @@ dependencies {
 
     compile 'com.github.machinarius:preferencefragment:0.1.1'
     compile 'org.achartengine:achartengine:1.2.0'
+
+    debugCompile 'com.facebook.stetho:stetho:1.0.0'
 }
 
 apply from: 'maven_publish.gradle'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     compile 'com.github.machinarius:preferencefragment:0.1.1'
     compile 'org.achartengine:achartengine:1.2.0'
 
-    debugCompile 'com.facebook.stetho:stetho:1.0.0'
+    debugCompile 'com.facebook.stetho:stetho:1.0.1'
 }
 
 apply from: 'maven_publish.gradle'

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.expidev.gcmapp">
+
+    <application
+        android:name=".DebugGcmApplication"
+        tools:replace="android:name"/>
+
+</manifest>

--- a/app/src/debug/java/com/expidev/gcmapp/DebugGcmApplication.java
+++ b/app/src/debug/java/com/expidev/gcmapp/DebugGcmApplication.java
@@ -1,0 +1,15 @@
+package com.expidev.gcmapp;
+
+import com.facebook.stetho.Stetho;
+
+public class DebugGcmApplication extends GcmApplication {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Stetho.initialize(
+                Stetho.newInitializerBuilder(this)
+                        .enableDumpapp(Stetho.defaultDumperPluginsProvider(this))
+                        .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(this))
+                        .build());
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:required="true" />
 
     <application
-        android:name="com.expidev.gcmapp.GcmApplication"
+        android:name=".GcmApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
I've found Stetho very handy for examining the SQLite databases. This will load it for debug builds only and not change anything for release builds.